### PR TITLE
Prompt consent for offline_access scope 

### DIFF
--- a/AeroGearOAuth2/OAuth2Module.swift
+++ b/AeroGearOAuth2/OAuth2Module.swift
@@ -115,7 +115,12 @@ public class OAuth2Module: AuthzModule {
         self.state = .AuthorizationStatePendingExternalApproval
 
         // calculate final url
-        let params = "?scope=\(config.scope)&redirect_uri=\(config.redirectURL.urlEncode())&client_id=\(config.clientId)&response_type=code"
+        var params = "?scope=\(config.scope)&redirect_uri=\(config.redirectURL.urlEncode())&client_id=\(config.clientId)&response_type=code"
+        // add consent prompt for online_access scope http://openid.net/specs/openid-connect-core-1_0.html#OfflineAccess
+        if config.scopes.contains("offline_access") {
+            params += "&prompt=consent"
+        }
+
         let url = NSURL(string:http.calculateURL(config.baseURL, url:config.authzEndpoint).absoluteString + params)
         if let url = url {
             if self.webView != nil {

--- a/AeroGearOAuth2/OpenStackOauth2Module.swift
+++ b/AeroGearOAuth2/OpenStackOauth2Module.swift
@@ -148,32 +148,6 @@ public class OpenStackOAuth2Module: OAuth2Module {
         })
     }
     
-    /**
-    Request to refresh an access token.
-    
-    :param: completionHandler A block object to be executed when the request operation finishes.
-    */
-    public override func refreshAccessToken(completionHandler: (AnyObject?, NSError?) -> Void) {
-        if let unwrappedRefreshToken = self.oauth2Session.refreshToken {
-            var paramDict: [String: String] = ["refresh_token": unwrappedRefreshToken, "client_id": config.clientId, "grant_type": "refresh_token"]
-            if (config.clientSecret != nil) {
-                paramDict["client_secret"] = config.clientSecret!
-            }
-            
-            http.POST(config.refreshTokenEndpoint!, parameters: paramDict, completionHandler: { (response, error) in
-                if (error != nil) {
-                    completionHandler(nil, error)
-                    return
-                }
-                
-                if let unwrappedResponse = response as? [String: AnyObject] {
-                    completionHandler(unwrappedResponse, nil);
-                }
-            })
-        }
-    }
-    
-    
     func decode(token: String) -> [String: AnyObject]? {
         let string = token.componentsSeparatedByString(".")
         let toDecode = string[1] as String


### PR DESCRIPTION
Implemented prompt consent for offline_access scope on base OAuth2Module, as detailed in http://openid.net/specs/openid-connect-core-1_0.html#OfflineAccess.

Overriden requestAuthorizationCode on OpenStack module to force approval prompt to allow multiple refresh token requests:
http://docs.openstack.org/infra/openstackid/oauth2.html#offline-access

Removed custom refreshToken handling on OpenStack module.
